### PR TITLE
Fix Redis security and update database plan

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -64,13 +64,10 @@ services:
     name: subscription-savor-redis
     plan: starter
     region: oregon
-    ipAllowList:
-      - source: 0.0.0.0/0
-        description: Allow access from all Render services
 
 databases:
   - name: subscription-savor-db
-    plan: starter
+    plan: free
     databaseName: subscription_savor
     user: subscription_user
     region: oregon


### PR DESCRIPTION
Secure Redis by removing public IP access and update database plan to `free` to resolve deprecation.