### PR TITLE
Fix deployment dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pytz==2023.3
 requests==2.31.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
-types-Flask==3.0.0.2
 types-python-telegram-bot==20.8.0.1


### PR DESCRIPTION
Remove `types-Flask` from `requirements.txt` to fix deployment errors.

The `types-Flask==3.0.0.2` dependency was causing deployment failures as this specific version does not exist. With Flask 3.0+, native type hints are included, making the separate `types-Flask` package redundant.