### PR TITLE
Troubleshoot deployment package errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ pytz==2023.3
 requests==2.31.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
-types-python-telegram-bot==20.8.0.1


### PR DESCRIPTION
Remove non-existent `types-python-telegram-bot` dependency to fix deployment.